### PR TITLE
Code golf

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,26 @@ module.exports = function asyncToGen(source, options) {
   return editor.toString();
 }
 
-var asyncHelper = "\nfunction __async(f){var g=f();return new Promise(function(s,j){c();function c(a,x){try{var r=g[x?'throw':'next'](a)}catch(e){return j(e)}if(r.done){s(r.value)}else{return Promise.resolve(r.value).then(c,function(e){return c(e,1)})}}})}\n";
+var asyncHelper = '\n' + [
+  'function __async(a){',
+    'var P=Promise,d=a();',
+    'return new P((a,e)=>{',
+      'var b=(f,g)=>{',
+        'try{',
+          'var c=d[g?"throw":"next"](f)',
+        '}catch(h){',
+          'return e(h)',
+        '}',
+        'if(c.done)',
+          'a(c.value);',
+        'else return P.resolve(c.value)',
+          '.then(b,a=>b(a,1))',
+      '};',
+      'b()',
+    '})',
+  '}',
+].join('') + '\n'
+
 module.exports.asyncHelper = asyncHelper;
 
 // A collection of methods for each AST type names which contain async functions to

--- a/test/expected.js
+++ b/test/expected.js
@@ -38,4 +38,4 @@ function within1() {return __async(function*(){
   }.bind(this))}
 })}
 
-function __async(f){var g=f();return new Promise(function(s,j){c();function c(a,x){try{var r=g[x?'throw':'next'](a)}catch(e){return j(e)}if(r.done){s(r.value)}else{return Promise.resolve(r.value).then(c,function(e){return c(e,1)})}}})}
+function __async(a){var P=Promise,d=a();return new P((a,e)=>{var b=(f,g)=>{try{var c=d[g?"throw":"next"](f)}catch(h){return e(h)}if(c.done)a(c.value);else return P.resolve(c.value).then(b,a=>b(a,1))};b()})}


### PR DESCRIPTION
This trims down the helper from 236 characters to 207.

There are three safe transforms:
- Cache `Promise` repeated twice into a variable
- Remove `{}` from a `if` and use one `;` instead
- Remove the last `;`

And an unsafe transform that uses arrow function instead of normal functions. This assumes that you are running in an enviromnent where there's both generators and arrow functions.

I mostly made this pull request for fun, feel free to close it without reviewing it :)