### PR TITLE
Use Function Representation And Stringify Where Appropriate

### DIFF
--- a/async-node
+++ b/async-node
@@ -95,7 +95,7 @@ if (evalScript || printScript) {
 
 // Or begin a REPL.
 } else {
-  global.__async = new Function('return ' + asyncToGen.asyncHelper)();
+  global.__async = asyncToGen.asyncHelper;
   repl.start({
     prompt: '> ',
     input: process.stdin,


### PR DESCRIPTION
Thanks for this neat little tool!

I was wondering why you are constructing the async helper function as a string, instead of using `Function.prototype.toString` when you need to insert the function into the raw code.

Benefits:
- Syntax highlighted code
- Presumably less (performance) implications with stringification rather than evaluating code

Please let me know if I missed any consideration for your decision :smile: