### PR TITLE
Add compatibility with Babel and elaborate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,21 @@ function foo() {return __async(function*(){
 
 function __async(g){/* small helper function */}
 ```
+
+
+## Using with Babel
+
+Don't bother using both! If you're already using Babel (maybe you need JSX,
+other proposed features, or are supporting older versions of Node) then you
+might be excited to hear that using [babel-preset-es2017](https://babeljs.io/docs/plugins/preset-es2017/)
+in your `.babelrc` will provide support for async functions!
+
+Babel is an amazing tool that you should consider using, however `async-to-gen`
+intentionally makes some different choices to provide a different set of
+trade-offs. Babel is general-purpose and supports a wider set of features but
+requires some configuration and more dependencies and those features may cost
+build performance or output code quality. `async-to-gen` can only do one thing,
+but that simplicity lends itself towards faster builds and cleaner output.
+
+Ultimately, if you only need to add async function support you should try
+`async-to-gen` but if you need more features then you should use Babel.

--- a/register.js
+++ b/register.js
@@ -1,16 +1,13 @@
-var fs = require('fs');
+var Module = require('module');
 var asyncToGen = require('./index');
 
-var prev = require.extensions['.js'];
-
-require.extensions['.js'] = function(module, filename) {
-  if (filename.indexOf('node_modules') === -1) {
-    var source = fs.readFileSync(filename, 'utf8');
-    module._compile(asyncToGen(source).toString(), filename);
-  } else if (prev) {
-    prev(module, filename);
-  } else {
-    var source = fs.readFileSync(filename, 'utf8');
-    module._compile(source, filename);
-  }
+// Rather than use require.extensions, swizzle Module#_compile. Not only does
+// this typically leverage the existing behavior of require.extensions['.js'],
+// but allows for use alongside other "require extension hook" if necessary.
+var super_compile = Module.prototype._compile;
+Module.prototype._compile = function _compile(source, filename) {
+  var transformedSource = filename.indexOf('node_modules/') === -1
+    ? asyncToGen(source).toString()
+    : source;
+  super_compile.call(this, transformedSource, filename);
 };


### PR DESCRIPTION
Fixes #11, #13, #15

This adds a section to the README about usage with Babel, but also changes the technique used by register.js to allow it to coexist with using `babel-register` to unbreak cases when async-node is used (intentionally or inadvertently) on a codebase using Babel.