### PR TITLE
[FIX] Fixes issue when referring to "arguments"

### DIFF
--- a/test/expected.js
+++ b/test/expected.js
@@ -91,6 +91,22 @@ function within1() {return __async(function*(){
   () => () =>__async(function*(){ return this}.call(this))
 }.call(this))}
 
+// normal function referencing arguments
+function normalThis() {
+  return arguments;
+}
+
+// async function referencing arguments
+function asyncThis() {return __async(function*(arguments){
+  return arguments;
+}(arguments))}
+
+// async arrow function referencing arguments
+function within1() {return __async(function*(arguments){
+  () => () =>__async(function*(arguments){ return arguments}(arguments))
+}(arguments))}
+
+
 class SuperDuper extends BaseClass {
   constructor(arg) {
     super(arg)

--- a/test/source.js
+++ b/test/source.js
@@ -91,6 +91,22 @@ async function within1() {
   () => async () => this
 }
 
+// normal function referencing arguments
+function normalThis() {
+  return arguments;
+}
+
+// async function referencing arguments
+async function asyncThis() {
+  return arguments;
+}
+
+// async arrow function referencing arguments
+async function within1() {
+  () => async () => arguments
+}
+
+
 class SuperDuper extends BaseClass {
   constructor(arg) {
     super(arg)

--- a/test/test-node-module.js
+++ b/test/test-node-module.js
@@ -5,7 +5,7 @@ async function genAnswer() {
     throw await
       true ?
         await
-          42 :
+          arguments[0] :
         await
           99
   } catch (e) {
@@ -13,4 +13,4 @@ async function genAnswer() {
   }
 }
 
-genAnswer().then(function (val) { console.log(val) });
+genAnswer(42).then(function (val) { console.log(val) });


### PR DESCRIPTION
Since the "arguments" variable can be overridden by the wrapping `function*(){}`, this passes the parent arguments value through explicitly if it was referenced.