### PR TITLE
[NEW] Async generator support.

### DIFF
--- a/async-node
+++ b/async-node
@@ -100,6 +100,7 @@ if (evalScript || printScript) {
 // Or begin a REPL.
 } else {
   global.__async = new Function('return ' + asyncToGen.asyncHelper)();
+  global.__asyncGen = new Function('return ' + asyncToGen.asyncGenHelper)();
   repl.start({
     prompt: '> ',
     input: process.stdin,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "http://github.com/leebyron/async-to-gen.git"
   },
   "scripts": {
-    "test": "DIFF=$(./async-to-gen test/source.js | diff test/expected.js -); if [ -n \"$DIFF\" ]; then echo \"$DIFF\"; exit 1; fi; RES=$(node -e 'require(\"./register\");require(\"./test/test-node-module.js\")'); if [ \"$RES\" != 42 ]; then echo 'Node register hook failed'; exit 1; fi; ASYNC_NODE=$(./async-node ./test/test-node-module.js); if [ \"$ASYNC_NODE\" != 42 ]; then echo 'async-node failed'; exit 1; fi;",
+    "test": "DIFF=$(./async-to-gen test/source.js | diff test/expected.js -); if [ -n \"$DIFF\" ]; then echo \"$DIFF\"; exit 1; fi; RES=$(node -e 'require(\"./register\");require(\"./test/test-node-module.js\")'); if [ \"$RES\" != 42 ]; then echo 'Node register hook failed'; exit 1; fi; ASYNC_NODE=$(./async-node ./test/test-node-module.js); if [ \"$ASYNC_NODE\" != 42 ]; then echo 'async-node failed'; exit 1; fi; ASYNC_GEN_NODE=$(./async-node ./test/test-async-generator.js); if [ \"$ASYNC_GEN_NODE\" != 42 ]; then echo 'async-node failed for async generators'; exit 1; fi;",
     "test-update": "./async-to-gen test/source.js > test/expected.js"
   },
   "keywords": [

--- a/test/expected.js
+++ b/test/expected.js
@@ -10,6 +10,16 @@ var bar = function() {return __async(function*(){
   yield x
 }())}
 
+// async gen function statement
+function foo() {return __asyncGen(function*(){
+  yield yield{__await: x}
+}())}
+
+// async gen function expression
+var bar = function () {return __asyncGen(function*(){
+  yield{__await: (yield x)}
+}())}
+
 // async arrow functions with body
 var arrow1 = () => __async(function*(){
   yield 42
@@ -23,6 +33,10 @@ var arrow2 = () =>__async(function*(){
 var obj = {
   baz() {return __async(function*(){
     yield this.x
+  }.call(this))},
+
+   bazGen() {return __asyncGen(function*(){
+    yield yield{__await: this.x}
   }.call(this))}
 }
 
@@ -31,12 +45,20 @@ class Dog {
   woof() {return __async(function*(){
     yield this.x
   }.call(this))}
+
+   woofGen() {return __asyncGen(function*(){
+    yield{__await: (yield this.x)};
+  }.call(this))}
 }
 
 // static async class method
 class Cat {
   static  miau() {return __async(function*(){
     yield this.x
+  }.call(this))}
+
+  static  woofGen() {return __asyncGen(function*(){
+    yield yield{__await: this.x};
   }.call(this))}
 }
 
@@ -177,4 +199,19 @@ function ownLine() {return __async(function*(){
     someThing);
 }())}
 
+// await gen on its own line
+function ownLineGen() {return __asyncGen(function*(){
+  yield{__await:
+    someThing};
+}())}
+
+// for await
+function mapStream(stream, mapper) {return __asyncGen(function*(){
+  for (let $await1 of stream) {let item=yield{__await:$await1};
+    yield yield{__await: mapper(item)};
+  }
+}())}
+
 function __async(g){return new Promise(function(s,j){function c(a,x){try{var r=g[x?"throw":"next"](a)}catch(e){return j(e)}return r.done?s(r.value):Promise.resolve(r.value).then(c,d)}function d(e){return c(e,1)}c()})}
+
+function __asyncGen(g){var q=[],T=["next","throw","return"],I={};for(var i=0;i<3;i++){I[T[i]]=a.bind(0,i)}Symbol&&(Symbol.iterator&&(I[Symbol.iterator]=t),Symbol.asyncIterator&&(I[Symbol.asyncIterator]=t));function t(){return this}function a(t,v){return new Promise(function(s,j){q.push([s,j,v,t]);q.length===1&&c(v,t)})}function c(v,t){try{var r=g[T[t|0]](v),w=r.value&&r.value.__await;w?Promise.resolve(w).then(c,d):n(r,0)}catch(e){n(e,1)}}function d(e){c(e,1)}function n(r,s){q.shift()[s](r);q.length&&c(q[0][2],q[0][3])}return I}

--- a/test/source.js
+++ b/test/source.js
@@ -10,6 +10,16 @@ var bar = async function() {
   await x
 }
 
+// async gen function statement
+async function* foo() {
+  yield await x
+}
+
+// async gen function expression
+var bar = async function* () {
+  await (yield x)
+}
+
 // async arrow functions with body
 var arrow1 = async () => {
   await 42
@@ -23,6 +33,10 @@ var arrow2 = async () =>
 var obj = {
   async baz() {
     await this.x
+  },
+
+  async* bazGen() {
+    yield await this.x
   }
 }
 
@@ -31,12 +45,20 @@ class Dog {
   async  woof() {
     await this.x
   }
+
+  async* woofGen() {
+    await (yield this.x);
+  }
 }
 
 // static async class method
 class Cat {
   static  async  miau() {
     await this.x
+  }
+
+  static async* woofGen() {
+    yield await this.x;
   }
 }
 
@@ -175,4 +197,17 @@ async function noRequiredParens() {
 async function ownLine() {
   await
     someThing;
+}
+
+// await gen on its own line
+async function* ownLineGen() {
+  await
+    someThing;
+}
+
+// for await
+async function* mapStream(stream, mapper) {
+  for await (let item of stream) {
+    yield await mapper(item);
+  }
 }

--- a/test/test-async-generator.js
+++ b/test/test-async-generator.js
@@ -1,0 +1,24 @@
+"use strict";
+
+async function* genAnswers() {
+  var stream = [ Promise.resolve(4), Promise.resolve(9), Promise.resolve(12) ];
+  var total = 0;
+  for await (let val of stream) {
+    total += await val;
+    yield total;
+  }
+}
+
+function forEach(ai, fn) {
+  return ai.next().then(function (r) {
+    if (!r.done) {
+      fn(r);
+      return forEach(ai, fn);
+    }
+  });
+}
+
+var output = 0;
+forEach(genAnswers(), function(val) { output += val.value }).then(function () {
+  console.log(output);
+});


### PR DESCRIPTION
This adds support for async generator functions which return async iterators (See: https://github.com/tc39/proposal-async-iteration).

It also will transform `for await` loops.

Async iterators and async generators are an exciting new proposal which is gaining traction within TC39 discussion. This will let you use them now with the same minimal approach.