### PR TITLE
fix mkdirp path when processing a source directory

### DIFF
--- a/async-to-gen
+++ b/async-to-gen
@@ -148,8 +148,8 @@ for (var i = 0; i < sources.length; i++) {
     var content = fs.readFileSync(source, 'utf8');
     var result = transformSource(content, source);
     if (outDir) {
-      mkdirp(path.dirname(path.join(outDir, source)));
       outFile = path.join(outDir, isDirSource ? path.relative(sources[0], source) : source);
+      mkdirp(path.dirname(outFile));
     }
     if (outFile) {
       fs.writeFileSync(outFile, result);


### PR DESCRIPTION
I was running into an odd issue with `async-to-gen --out-dir out src` where the tool would try to write files to directories that don't exist. For example, my `src` directory looked like:
```
src\
src\index.js
src\subfolder\
src\subfolder\index.js
```
After running the tool, the out directory looked like
```
out\
out\index.js
out\src\
out\src\subfolder
```
and then it would panic when it tried to write to `out\subfolder\index.js`, because that directory didn't exist. FWIW I'm working on Windows, which might have different behavior for `path.join` or `path.dirname`. The above change fixed the issue for me, and I don't see any issues with taking the directory path straight from the output file path, but I can't test it really thoroughly right now.