### PR TITLE
for-await-of and AsyncIterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ var ticker = stockTickerInEuro('AAPL')
 ticker.next().then(step => console.log(step.value))
 ```
 
-Or use `for-await` loops within another async function:
+Or use `for-await-of` loops within another async function:
 
 ```js
 async function bloombergTerminal() {
@@ -242,8 +242,8 @@ async function bloombergTerminal() {
 }
 ```
 
-NOTE: The behavior of `for-await` loops using this tool is not identical to the
-proposed spec addition. Where the proposed spec's `for-await` expects a
+NOTE: The behavior of `for-await-of` loops using this tool is not identical to the
+proposed spec addition. Where the proposed spec's `for-await-of` expects a
 `Symbol.asyncIterator` method for the iterated source, this tool expects
 `Symbol.iterator` instead since it transforms it to a `for-of` loop.
 

--- a/async-node
+++ b/async-node
@@ -101,6 +101,7 @@ if (evalScript || printScript) {
 } else {
   global.__async = new Function('return ' + asyncToGen.asyncHelper)();
   global.__asyncGen = new Function('return ' + asyncToGen.asyncGenHelper)();
+  global.__asyncIterator = new Function('return ' + asyncToGen.asyncIteratorHelper)();
   repl.start({
     prompt: '> ',
     input: process.stdin,

--- a/test/expected.js
+++ b/test/expected.js
@@ -221,16 +221,16 @@ function ownLineGen() {return __asyncGen(function*(){
 
 // for await
 function mapStream(stream, mapper) {return __asyncGen(function*(){
-  for (let $await1 of stream) {let item=yield{__await:$await1};
+  var $i1,$s1,$e1;try{for ($s1=null,$i1=__asyncIterator( stream);$s1=yield{__await:$i1.next()},!$s1.done;) {let item=$s1.value;
     yield yield{__await: mapper(item)};
-  }
+  }}catch(e){$e1=e}finally{try{!$s1.done&&$i1.return&&(yield{__await:$i1.return()})}finally{if($e1)throw $e1}}
 }())}
 
 function reduceStream(stream, reducer, initial) {return __async(function*(){
   var value = initial;
-  for (let $await1 of stream) {let item=yield $await1;
-    value = reducer(value, yield mapper(item));
-  }
+  var $i1,$s1,$e1;try{for ($s1=null,$i1=__asyncIterator( stream);$s1=yield $i1.next(),!$s1.done;) {let item=$s1.value;
+    value = reducer(value, item);
+  }}catch(e){$e1=e}finally{try{!$s1.done&&$i1.return&&(yield $i1.return())}finally{if($e1)throw $e1}}
   return value;
 }())}
 
@@ -239,4 +239,6 @@ const [,holey] = [1,2,3]
 
 function __async(g){return new Promise(function(s,j){function c(a,x){try{var r=g[x?"throw":"next"](a)}catch(e){j(e);return}r.done?s(r.value):Promise.resolve(r.value).then(c,d)}function d(e){c(e,1)}c()})}
 
-function __asyncGen(g){var q=[],T=["next","throw","return"],I={};for(var i=0;i<3;i++){I[T[i]]=a.bind(0,i)}Symbol&&(Symbol.iterator&&(I[Symbol.iterator]=t),Symbol.asyncIterator&&(I[Symbol.asyncIterator]=t));function t(){return this}function a(t,v){return new Promise(function(s,j){q.push([s,j,v,t]);q.length===1&&c(v,t)})}function c(v,t){try{var r=g[T[t|0]](v),w=r.value&&r.value.__await;w?Promise.resolve(w).then(c,d):n(r,0)}catch(e){n(e,1)}}function d(e){c(e,1)}function n(r,s){q.shift()[s](r);q.length&&c(q[0][2],q[0][3])}return I}
+function __asyncGen(g){var q=[],T=["next","throw","return"],I={};for(var i=0;i<3;i++){I[T[i]]=a.bind(0,i)}I[Symbol?Symbol.asyncIterator||(Symbol.asyncIterator=Symbol()):"@@asyncIterator"]=function (){return this};function a(t,v){return new Promise(function(s,j){q.push([s,j,v,t]);q.length===1&&c(v,t)})}function c(v,t){try{var r=g[T[t|0]](v),w=r.value&&r.value.__await;w?Promise.resolve(w).then(c,d):n(r,0)}catch(e){n(e,1)}}function d(e){c(e,1)}function n(r,s){q.shift()[s](r);q.length&&c(q[0][2],q[0][3])}return I}
+
+function __asyncIterator(o){var i=o[Symbol&&Symbol.asyncIterator||"@@asyncIterator"]||o[Symbol&&Symbol.iterator||"@@iterator"];if(!i)throw new TypeError("Object is not AsyncIterable.");return i.call(o)}

--- a/test/source.js
+++ b/test/source.js
@@ -229,7 +229,7 @@ async function* mapStream(stream, mapper) {
 async function reduceStream(stream, reducer, initial) {
   var value = initial;
   for await (let item of stream) {
-    value = reducer(value, await mapper(item));
+    value = reducer(value, item);
   }
   return value;
 }

--- a/test/test-async-generator.js
+++ b/test/test-async-generator.js
@@ -1,9 +1,80 @@
 "use strict";
 
+// Throwing, catching and finally.
+
+var events = [];
+async function* getThrow() {
+  async function* source() {
+    try {
+      yield await Promise.resolve(1);
+      yield await Promise.resolve(2);
+    } finally {
+      events.push('source finally');
+      throw new Error('Source Finally Error');
+    }
+  }
+
+  var iter1 = source();
+  try {
+    for await (let val of iter1) {
+      yield val;
+      break;
+    }
+  } catch (e) {
+    events.push('getThrow1 caught: ' + e);
+  } finally {
+    events.push('getThrow1 finally');
+    events.push('getThrow1 iter: ' + JSON.stringify(await iter1.next()));
+  }
+
+  var iter2 = source();
+  try {
+    for await (let val of iter2) {
+      yield val;
+      throw new Error('Inner Error');
+    }
+  } finally {
+    events.push('getThrow2 finally');
+    events.push('getThrow2 iter: ' + JSON.stringify(await iter2.next()));
+  }
+
+  events.push('UNEXPECTED');
+}
+
+var collected = [];
+forEach(getThrow(), function(val) {
+  events.push('yielded: ' + JSON.stringify(val))
+}).catch(function (e) {
+  events.push('caught: ' + e);
+}).then(function () {
+  if (JSON.stringify(events) !== JSON.stringify([
+    'yielded: {"value":1,"done":false}',
+    'source finally',
+    'getThrow1 caught: Error: Source Finally Error',
+    'getThrow1 finally',
+    'getThrow1 iter: {"done":true}',
+    'yielded: {"value":1,"done":false}',
+    'source finally',
+    'getThrow2 finally',
+    'getThrow2 iter: {"done":true}',
+    'caught: Error: Inner Error'
+  ])) {
+    console.error(events);
+    throw new Error('Unexpected sequence of events.');
+  }
+});
+
+// Stream producing value.
+
+async function* stream() {
+  yield await 4;
+  yield await 9;
+  yield await 12;
+}
+
 async function* genAnswers() {
-  var stream = [ Promise.resolve(4), Promise.resolve(9), Promise.resolve(12) ];
   var total = 0;
-  for await (let val of stream) {
+  for await (let val of stream()) {
     total += await val;
     yield total;
   }


### PR DESCRIPTION
> This is a minor breaking change for for-await-of which no longer awaits the value, only awaits the iterator step result.

This adds a proper transform of for-await-of to a standard loop in order to leverage async-iterable interface correctly. Previously the behavior was just broken. Async-iterator functions were returning proper async-iterables, however for-await was not reading them correctly.