### PR TITLE
Improve node_modules check

### DIFF
--- a/register.js
+++ b/register.js
@@ -6,7 +6,8 @@ var asyncToGen = require('./index');
 // but allows for use alongside other "require extension hook" if necessary.
 var super_compile = Module.prototype._compile;
 Module.prototype._compile = function _compile(source, filename) {
-  var transformedSource = filename.indexOf('node_modules/') === -1
+  var parentDir = __dirname.substr(0, __dirname.lastIndexOf('node_modules'))
+  var transformedSource = filename.replace(parentDir, '').indexOf('node_modules') === -1
     ? asyncToGen(source).toString()
     : source;
   super_compile.call(this, transformedSource, filename);


### PR DESCRIPTION
Allows you to use async-to-gen on the fly without compiling.

The simple 'node_modules' check fails if the module is installed as a dependency, because obviously it would itself live in a node_modules folder. Instead this checks that the module is outside of the correct node_modules folder