### PR TITLE
Use pirates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ exclude any files.
 require('async-to-gen/register')({ includes: /\/custom_path\// })
 ```
 
+The require hook also offers the ability to set options and revert the require
+hook:
+
+```js
+const asyncHook = require('async-to-gen/register')
+// Similar to example above.
+asyncHook.setOptions({ includes: /\/custom_path\// })
+// Reverts the require hook.
+asyncHook.revert()
+```
+
 > #### Don't use the require hook in packages distributed on NPM
 > As always, don't forget to use `async-to-gen` to compile files before distributing
 > your code on npm, as using the require hook affects the whole runtime and not

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "babylon": "^6.14.0",
-    "magic-string": "^0.22.0"
+    "magic-string": "^0.22.0",
+    "pirates": "^3.0.2"
   }
 }


### PR DESCRIPTION
instead of a manual swizzling, which provides better interop with babel and std/esm as well as provides a slightly more useful API

Suggested in #51