### PR TITLE
Always write as utf8

### DIFF
--- a/async-to-gen
+++ b/async-to-gen
@@ -202,11 +202,11 @@ function transformAndOutput(content, outFile, source) {
   }
 
   if (outFile) {
-    fs.writeFileSync(outFile, code);
+    fs.writeFileSync(outFile, code, 'utf8');
     info(fileName + '\n \u21B3 \033[32m' + outFile + '\033[0m\n');
     if (sourceMaps && !inlineSourceMaps) {
       var mapOutFile = outFile + '.map';
-      fs.writeFileSync(mapOutFile, JSON.stringify(map) + '\n');
+      fs.writeFileSync(mapOutFile, JSON.stringify(map) + '\n', 'utf8');
       info('\033[2m \u21B3 \033[32m' + mapOutFile + '\033[0m\n');
     }
   } else {


### PR DESCRIPTION
Fixes #50

Since we explicitly always read assuming utf8, we should also write assuming utf8.

See also: http://utf8everywhere.org/